### PR TITLE
WIP: Add Claude Code plugin for improveit skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "improveit",
+  "version": "0.1.0",
+  "description": "Add codespell and shellcheck support to any project",
+  "author": "Yaroslav Halchenko"
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,5 +2,5 @@
   "name": "improveit",
   "version": "0.1.0",
   "description": "Add codespell and shellcheck support to any project",
-  "author": "Yaroslav Halchenko"
+  "author": { "name": "Yaroslav Halchenko" }
 }

--- a/skills/improveit/SKILL.md
+++ b/skills/improveit/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: improveit
+description: >
+  This skill should be used when the user asks to "add codespell", "add spell checking",
+  "set up codespell", "add shellcheck", "set up shellcheck", "add linting",
+  "improve code quality", "add code quality tools", or mentions "improveit".
+  Adds codespell (spell checking) and/or shellcheck (shell linting) to projects
+  with GitHub Actions workflows, configs, pre-commit hooks, automatic fixing, and PRs.
+---
+
+# improveit
+
+Add codespell and/or shellcheck support to any Git project. This skill orchestrates
+battle-tested shell scripts that handle the full workflow: detect project structure,
+create configuration files, add GitHub Actions workflows, set up pre-commit hooks,
+automatically fix issues, and open a pull request.
+
+## Prerequisites
+
+Before running any improveit script, verify these tools are available:
+
+- **codespell** — spell checker (`pip install codespell`)
+- **shellcheck** — shell script linter (via package manager)
+- **gh** — GitHub CLI, authenticated (`gh auth login`)
+- **datalad** — data management tool (`pip install datalad`)
+- **git** — with `github.user` configured (`git config --global github.user USERNAME`)
+
+Check prerequisites by running:
+
+```bash
+command -v codespell && command -v shellcheck && command -v gh && command -v datalad && git config github.user
+```
+
+If any prerequisite is missing, inform the user and suggest how to install it before proceeding.
+
+## Adding Codespell Support
+
+To add codespell to the current project, run the full codespellit workflow:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/codespellit
+```
+
+This single command performs the entire workflow:
+
+1. Creates a feature branch `enh-codespell`
+2. Detects files to skip (PDFs, SVGs, lock files, etc.)
+3. Creates codespell config (in `pyproject.toml`, `setup.cfg`, or `.codespellrc`)
+4. Generates a GitHub Actions workflow (`.github/workflows/codespell.yml`)
+5. Adds codespell to `.pre-commit-config.yaml` (if it exists)
+6. Commits all configuration
+7. Runs `codespell -w` via datalad to auto-fix typos
+8. Runs interactive fixing for ambiguous typos (requires user input)
+9. Pushes to a fork remote and opens a PR
+
+**Important:** Step 8 (`datalad-run-w-i`) is interactive — it prompts for each ambiguous typo. The user must interact with this step. Inform the user before running the full workflow that it will require their input for ambiguous fixes.
+
+**Important:** The script sources `common.sh` on startup, which automatically forks the upstream repo on GitHub and adds a remote. This is expected behavior.
+
+To run individual steps instead of the full workflow, use subcommands. See `references/subcommands.md` for details.
+
+## Adding Shellcheck Support
+
+To add shellcheck to the current project, run:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/shellcheckit
+```
+
+This performs the workflow:
+
+1. Detects shell scripts by scanning for shebangs (`#!/bin/bash`, `#!/usr/bin/env sh`, etc.)
+2. If no shell scripts are found, exits with a message
+3. Creates a feature branch `enh-shellcheck`
+4. Generates a GitHub Actions workflow (`.github/workflows/shellcheck.yml`)
+5. Adds shellcheck to `.pre-commit-config.yaml` (if it exists)
+6. Runs shellcheck on all detected scripts and reports findings
+
+Unlike codespellit, shellcheckit does **not** automatically push or create a PR. After running, review the shellcheck output with the user and help fix any issues. Then commit, push, and create a PR manually.
+
+To apply automatic shellcheck fixes:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/shellcheckit autopatch
+```
+
+## Selective Operations
+
+Both scripts support subcommands for running individual steps. Common patterns:
+
+**List issues without fixing:**
+```bash
+${CLAUDE_PLUGIN_ROOT}/codespellit list          # List typos
+${CLAUDE_PLUGIN_ROOT}/shellcheckit doit          # Run shellcheck
+```
+
+**Just add workflows/configs (no fixing):**
+```bash
+${CLAUDE_PLUGIN_ROOT}/shellcheckit generate_workflow
+```
+
+For the full subcommand reference, consult `references/subcommands.md`.
+
+## Workflow Summary
+
+When the user asks to "add codespell" or "add shellcheck" or both:
+
+1. Confirm which tools to add (codespell, shellcheck, or both)
+2. Verify prerequisites are installed
+3. Run the appropriate script(s)
+4. Monitor output and assist with any interactive prompts
+5. Review the results with the user
+6. For shellcheckit: help fix issues and create the PR manually
+
+When adding both tools, run codespellit first, then shellcheckit, as they create separate branches.
+
+## Additional Resources
+
+### Reference Files
+
+For detailed subcommand documentation:
+- **`references/subcommands.md`** — Complete subcommand reference for both codespellit and shellcheckit

--- a/skills/improveit/references/subcommands.md
+++ b/skills/improveit/references/subcommands.md
@@ -1,0 +1,95 @@
+# Subcommand Reference
+
+## codespellit Subcommands
+
+Run any subcommand with: `${CLAUDE_PLUGIN_ROOT}/codespellit <subcommand> [args]`
+
+### `list [args]`
+
+List typos found by codespell. Passes extra arguments to codespell. If codespell
+finds typos, also shows a filtered view of ambiguous ones (lines containing commas
+in the suggestion).
+
+### `list-hits-sorted [args]`
+
+Show typos sorted by frequency count. Useful for prioritizing which typos to fix
+first. Output format: `count suggestion`.
+
+### `fix-sorted <file>`
+
+Apply fixes from a filtered list file. The file should contain lines with `==>`
+(output from `list-hits-sorted` after manual filtering). Requires a clean git
+working tree. Creates a commit with all fixes.
+
+Workflow:
+1. Run `list-hits-sorted > /tmp/fixes.txt`
+2. Edit the file to keep only desired fixes
+3. Run `fix-sorted /tmp/fixes.txt`
+
+### `deduce-config`
+
+Print the path to the codespell configuration file. Checks in order:
+`.codespellrc`, `pyproject.toml` (for `[tool.codespell]`), `setup.cfg` (for
+`[codespell]`).
+
+### `add-precommit [config]`
+
+Add codespell to `.pre-commit-config.yaml`. If the file exists, appends a
+codespell entry with the current codespell version. If `config` is `pyproject.toml`,
+adds `tomli` as an additional dependency. Commits the change.
+
+### `datalad-run-w`
+
+Auto-fix all typos via `datalad run -m "..." 'codespell -w'`. Creates a tracked
+commit through datalad.
+
+### `datalad-run-w-i`
+
+Interactive typo fixing via `datalad run -m "..." codespell -w -i 3 -C 2`.
+Prompts for each ambiguous typo with context. Requires user interaction.
+
+### `send-pr`
+
+Push the current branch to a fork remote and create a pull request on GitHub.
+Sets up a fork remote if needed (using `gh repo fork`).
+
+### `detect-platform`
+
+Print the detected hosting platform: `github`, `codeberg`, `forgejo`, or
+`unknown`. Detection is based on the origin remote URL.
+
+### `setup-fork-remote`
+
+Set up a fork remote for pushing. On GitHub, forks the repo via `gh` and adds
+a `gh-{username}` remote. Returns the remote name.
+
+### `clone <url>`
+
+Clone a repository with `--filter=blob:none` (partial clone) and enter the
+directory. Used as a convenience for starting work on a new repo.
+
+## shellcheckit Subcommands
+
+Run any subcommand with: `${CLAUDE_PLUGIN_ROOT}/shellcheckit <subcommand> [args]`
+
+### `list [args]`
+
+List all shell scripts detected in the repository. Detection uses shebang
+patterns matching sh, bash, dash, and ksh interpreters. Excludes `.txt` and
+`.md` files.
+
+### `doit [args]`
+
+Run shellcheck on all detected shell scripts. Passes extra arguments to
+shellcheck.
+
+### `autopatch [args]`
+
+Apply automatic shellcheck fixes. Runs `shellcheck -f diff` on all detected
+scripts and applies the resulting patch.
+
+### `generate_workflow`
+
+Generate `.github/workflows/shellcheck.yml` without creating a branch or
+committing. If the workflow already exists, preserves the existing branch
+configuration.


### PR DESCRIPTION
## Summary

Adds Claude Code plugin structure so improveit can be used as a skill inside Claude Code. Instead of remembering script paths and subcommands, users can say things like "add codespell support" or "add shellcheck to this project".

## How to install

### Option 1: Local testing

```bash
claude --plugin-dir /path/to/improveit
```

### Option 2: Custom marketplace

Add to `~/.claude/settings.json`:

```json
{
  "extraKnownMarketplaces": {
    "improveit": {
      "source": {
        "source": "url",
        "url": "https://github.com/yarikoptic/improveit.git"
      }
    }
  }
}
```

Then install via `/plugin install improveit@improveit` in Claude Code.

## What's added

- `.claude-plugin/plugin.json` — Plugin manifest
- `skills/improveit/SKILL.md` — Orchestration skill that tells Claude how to run codespellit/shellcheckit
- `skills/improveit/references/subcommands.md` — Detailed subcommand reference

No existing scripts are modified. The skill references `${CLAUDE_PLUGIN_ROOT}/codespellit` and `${CLAUDE_PLUGIN_ROOT}/shellcheckit` which resolve to the repo root.

## Usage

Once installed, in any repo:
- "add codespell support" — runs the full codespellit workflow
- "add shellcheck" — runs shellcheckit
- "list codespell typos" — runs individual subcommands

## Status

WIP — needs testing in real repos to verify the skill triggers correctly and scripts run as expected.